### PR TITLE
Set is_human_readable to false on Serializer and Deserializer

### DIFF
--- a/src/cdr_deserializer.rs
+++ b/src/cdr_deserializer.rs
@@ -397,6 +397,10 @@ where
   {
     self.deserialize_any(visitor)
   }
+
+  fn is_human_readable(&self) -> bool {
+      false
+  }
 }
 
 // ----------------------------------------------------------

--- a/src/cdr_serializer.rs
+++ b/src/cdr_serializer.rs
@@ -464,6 +464,10 @@ where
     self.serialize_u32(variant_index)?;
     Ok(self)
   }
+
+  fn is_human_readable(&self) -> bool {
+      false
+  }
 }
 
 impl<'a, W: io::Write, BO: ByteOrder> ser::SerializeSeq for &'a mut CdrSerializer<W, BO> {


### PR DESCRIPTION
This PR resolves issue #1.

## Modification description

Override the `serde` `is_human_readable` method to return `false` for CDR `Serializer` and `Deserializer`, to convey that it isn't a human readable format, to allow  for flexible serialization / deserialization based on the type of the (de)serializer (human-readable: JSON / YAML, binary: CDR)

## Test performed

See #1 example.

## Functional impact

Per serde documentation of the [is_human_readable](https://docs.rs/serde/latest/serde/trait.Serializer.html#method.is_human_readable) function, changing this is regarded as a breaking change. 
 