### PR TITLE
feat: support byte buf (de)serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Serde implementation of OMG Common Data Representation (CDR) enco
 readme = "README.md"
 keywords = ["network","protocol","dds","rtps"]
 license = "Apache-2.0"
-homepage = "https://atostek.com/en/products/rustdds/"  
+homepage = "https://atostek.com/en/products/rustdds/"
 repository = "https://github.com/jhelovuo/cdr-encoding"
 
 [workspace]
@@ -19,7 +19,7 @@ members = [
 ]
 
 
-# Although cdr-encoding, cdr-encoding-size, and cdr-encoding-size-derive 
+# Although cdr-encoding, cdr-encoding-size, and cdr-encoding-size-derive
 # are relaed semantically,
 # the main crate cdr-encoding does not technically depend on the two others.
 #

--- a/src/cdr_deserializer.rs
+++ b/src/cdr_deserializer.rs
@@ -267,7 +267,15 @@ where
   where
     V: Visitor<'de>,
   {
-    self.deserialize_seq(visitor)
+    // Align to 4 bytes
+    self.calculate_padding_count_from_written_bytes_and_remove(4)?;
+    // Length prefix
+    let len = self.next_bytes(4)?.read_u32::<BO>().unwrap() as usize;
+    // Read the entire buffer at once
+    let buf = self.next_bytes(len)?.to_vec();
+
+    visitor.visit_byte_buf(buf)
+
   }
 
   fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>

--- a/src/cdr_serializer.rs
+++ b/src/cdr_serializer.rs
@@ -322,7 +322,7 @@ where
 
   fn serialize_bytes(self, v: &[u8]) -> Result<()> {
     // Write length prefix
-    self.writer.write_all(&v.len().to_le_bytes())?;
+    self.serialize_u32(v.len() as u32)?;
     // Write raw bytes
     self.writer.write_all(v)?;
     Ok(())

--- a/src/cdr_serializer.rs
+++ b/src/cdr_serializer.rs
@@ -321,6 +321,9 @@ where
   }
 
   fn serialize_bytes(self, v: &[u8]) -> Result<()> {
+    // Write length prefix
+    self.writer.write_all(&v.len().to_le_bytes())?;
+    // Write raw bytes
     self.writer.write_all(v)?;
     Ok(())
   }


### PR DESCRIPTION
Hello!

With this PR, users can call `deserialize_byte_buf` with bulk read for messages defined like this.

```rust
#[derive(Debug, Serialize, Deserialize, Default, Clone)]
pub struct ByteMultiArray {
    pub layout: MultiArrayLayout,
    #[serde(with = "serde_bytes")]
    pub data: Vec<u8>,
}
```

This saves a lot of CPU usage.