### PR TITLE
Replace crate: paste with pastey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,22 +5,18 @@ edition = "2018"
 authors = ["Juhana Helovuo <juhana.helovuo@atostek.com>"]
 description = "Serde implementation of OMG Common Data Representation (CDR) encoding"
 readme = "README.md"
-keywords = ["network","protocol","dds","rtps"]
+keywords = ["network", "protocol", "dds", "rtps"]
 license = "Apache-2.0"
-homepage = "https://atostek.com/en/products/rustdds/"  
+homepage = "https://atostek.com/en/products/rustdds/"
 repository = "https://github.com/jhelovuo/cdr-encoding"
 
 [workspace]
 resolver = "2"
-members = [
-    ".",
-    "cdr-encoding-size",
-    "cdr-encoding-size-derive",
-]
+members = [".", "cdr-encoding-size", "cdr-encoding-size-derive"]
 
 
 # Although cdr-encoding, cdr-encoding-size, and cdr-encoding-size-derive 
-# are relaed semantically,
+# are related semantically,
 # the main crate cdr-encoding does not technically depend on the two others.
 #
 # Naturally, cdr-encoding-size does depend on cdr-encoding-size-derive.
@@ -30,9 +26,9 @@ members = [
 [dependencies]
 log = "0.4.11"
 serde = { version = "1.0", features = ["derive"] }
-serde_repr="0.1"
+serde_repr = "0.1"
 byteorder = { version = "1.3", features = ["i128"] }
-paste = "1"
+pastey = "0.2.0"
 thiserror = "1.0.29"
 static_assertions = "1.1"
 

--- a/src/cdr_deserializer.rs
+++ b/src/cdr_deserializer.rs
@@ -5,7 +5,7 @@ use byteorder::{BigEndian, LittleEndian};
 use byteorder::{ByteOrder, ReadBytesExt};
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
-use paste::paste;
+use pastey::paste;
 #[cfg(test)]
 use serde::de::DeserializeOwned;
 use serde::de::{


### PR DESCRIPTION
`paste` is no longer maintained and thus triggers some advisory warnings. `pastey`is a drop-in replacement with the same API.

Also fixed some small typos and formatting.